### PR TITLE
Update to use Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: 'DO secret key'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
Fixes #623
- This will remove warnings reported from GitHub which will deprecate Node12 in the near future on their runners.