### PR TITLE
Allow `source` to use an absolute path

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,7 @@ const config = {
 		key: 'source',
 		required: true,
 		modifier: (val) => {
-			return path.join(process.cwd(), val)
+			return path.resolve(process.cwd(), val)
 		}
 	}),
 	outDir: getInput({


### PR DESCRIPTION
By replacing `path.join()` with `path.resolve()` in `config.js`, this allows the use of absolute paths in the `source` option. This has been tested on Ubuntu, macOS and Windows, in particular Windows-style `C:\path\to\etc` style paths.

Fixes #911.