### PR TITLE
update action to run on node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: 'DO secret key'
     required: false
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
GitHub has [already been forcing actions](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) to use Node20 since June. This will just get rid of the deprecation warning every time this action runs.
